### PR TITLE
change default dtype to int64 for larger test cases

### DIFF
--- a/rene.py
+++ b/rene.py
@@ -9,7 +9,7 @@ class MainTransformer(Transformer):
     boilerplate = """######## rene boilerplate ########
 import numpy as np
 
-def Array(*dimensions, dtype=np.int32):
+def Array(*dimensions, dtype=np.int64):
     return np.empty([x + 1 for x in dimensions], dtype)
 Table = Array
 


### PR DESCRIPTION
Overflow warnings are thrown for significantly large enough test cases. Changing the default dtype of the Array/Table from int32 to int64 allows for much larger testing scenarios.